### PR TITLE
Fix updater not workin under Wine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,16 +376,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,21 +609,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -902,6 +877,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,19 +899,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -1037,9 +1012,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "link-cplusplus"
@@ -1145,24 +1120,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,50 +1172,6 @@ checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
 dependencies = [
  "pathdiff",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.15",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -1595,20 +1508,21 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -1616,7 +1530,23 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1649,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.12"
+version = "0.37.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722529a737f5a942fdbac3a46cee213053196737c5eaa3386d52e85b786f2659"
+checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -1659,6 +1589,27 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -1683,15 +1634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
-dependencies = [
- "windows-sys 0.42.0",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,26 +1646,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
-name = "security-framework"
-version = "2.8.2"
+name = "sct"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1811,6 +1740,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
@@ -1967,13 +1902,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
+name = "tokio-rustls"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "native-tls",
+ "rustls",
  "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -2227,6 +2163,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,12 +2184,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2368,6 +2304,25 @@ checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3"
 humansize = "1.1"
 path-slash = "0.2.1"
 open = "3.0"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"

--- a/src/bin/rose-updater-archive.rs
+++ b/src/bin/rose-updater-archive.rs
@@ -100,10 +100,10 @@ async fn main() -> anyhow::Result<()> {
 
         let output_relative_path = &args
             .archive_prefix_dir
-            .join(&input_relative_path)
+            .join(input_relative_path)
             .with_extension(format!("{}.{}", &input_extension, &args.archive_extension));
 
-        let output_path = (&args.output).join(&output_relative_path);
+        let output_path = args.output.join(output_relative_path);
 
         println!("{} => {}", input_path.display(), output_path.display());
 

--- a/src/bin/rose-updater.rs
+++ b/src/bin/rose-updater.rs
@@ -3,9 +3,8 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::Duration;
 
-use anyhow::{Context, bail};
+use anyhow::{bail, Context};
 use async_trait::async_trait;
 use clap::Parser;
 use fltk::frame::Frame;
@@ -20,7 +19,10 @@ use tracing_subscriber::FmtSubscriber;
 #[cfg(feature = "console")]
 use console_subscriber;
 
-use rose_update::{clone_remote, launch_button, progress_bar, LocalManifest, LocalManifestFileEntry, RemoteManifest, Updater, RemoteManifestFileEntry};
+use rose_update::{
+    clone_remote, launch_button, progress_bar, LocalManifest, LocalManifestFileEntry,
+    RemoteManifest, RemoteManifestFileEntry, Updater,
+};
 
 const LOCAL_MANIFEST_VERSION: usize = 1;
 const UPDATER_OLD_EXT: &str = "old";
@@ -79,7 +81,7 @@ async fn save_local_manifest(manifest_path: &Path, manfiest: &LocalManifest) -> 
         std::fs::create_dir_all(manifest_parent_dir)?;
     }
 
-    let manifest_file = std::fs::File::create(&manifest_path)?;
+    let manifest_file = std::fs::File::create(manifest_path)?;
     serde_json::to_writer(manifest_file, &manfiest)?;
 
     info!("Saved local manifest to {}", manifest_path.display());
@@ -89,19 +91,28 @@ async fn save_local_manifest(manifest_path: &Path, manfiest: &LocalManifest) -> 
 
 enum DownloadResult {
     ApplicationUpdated,
-    UpdaterUpdated
+    UpdaterUpdated,
 }
 
-async fn get_remote_manifest(remote_url: &Url, manifest_name: &str) -> anyhow::Result<RemoteManifest> {
+async fn get_remote_manifest(
+    remote_url: &Url,
+    manifest_name: &str,
+) -> anyhow::Result<RemoteManifest> {
     info!("Downloading remote manifest");
     // Download our remote manifest file
     let remote_manifest_url = remote_url.join(manifest_name)?;
     Ok(reqwest::get(remote_manifest_url)
         .await?
-        .json::<RemoteManifest>().await?)
+        .json::<RemoteManifest>()
+        .await?)
 }
 
-async fn update_updater(local_updater_path: &PathBuf, updater_output_path: &PathBuf, remote_url: &Url, main_updater: MainProgressUpdater) -> anyhow::Result<()> {
+async fn update_updater(
+    local_updater_path: &Path,
+    updater_output_path: &Path,
+    remote_url: &Url,
+    main_updater: MainProgressUpdater,
+) -> anyhow::Result<()> {
     // When the updater needs to be updated we change the exe name before
     // restarting the process. This step ensures that we delete the old,
     // outdated updater exe.
@@ -130,18 +141,15 @@ async fn update_updater(local_updater_path: &PathBuf, updater_output_path: &Path
             ))?;
     }
 
-    clone_remote(
-        &remote_url,
-        &updater_output_path,
-        main_updater,
-    )
+    clone_remote(remote_url, updater_output_path, main_updater)
         .await
-        .context(format!(
-            "Failed to clone {}",
-            &remote_url
-        ))?;
+        .context(format!("Failed to clone {}", &remote_url))?;
 
-    info!("Cloned {} to {}", &remote_url, updater_output_path.display());
+    info!(
+        "Cloned {} to {}",
+        &remote_url,
+        updater_output_path.display()
+    );
 
     Ok(())
 }
@@ -151,20 +159,20 @@ async fn get_local_manifest(folder: &PathBuf) -> anyhow::Result<LocalManifest> {
 
     // Read the manifest file if we can. Otherwise we default to an empty local
     // manifest which we save as a new manifest later.
-    let local_manifest = if folder.try_exists().context("Failed to get the local manifest")? {
-            info!(
-                "Using existing manifest file: {}",
-                folder.display()
-            );
+    let local_manifest = if folder
+        .try_exists()
+        .context("Failed to get the local manifest")?
+    {
+        info!("Using existing manifest file: {}", folder.display());
 
-            let file = File::open(&folder).await?;
-            match serde_json::from_reader(file.into_std().await) {
-                Ok(manifest) => manifest,
-                Err(_) => {
-                    info!("Failed to parse local manifest");
-                    LocalManifest::default()
-                }
+        let file = File::open(&folder).await?;
+        match serde_json::from_reader(file.into_std().await) {
+            Ok(manifest) => manifest,
+            Err(_) => {
+                info!("Failed to parse local manifest");
+                LocalManifest::default()
             }
+        }
     } else {
         LocalManifest::default()
     };
@@ -172,7 +180,13 @@ async fn get_local_manifest(folder: &PathBuf) -> anyhow::Result<LocalManifest> {
     Ok(local_manifest)
 }
 
-fn verify_local_files(output: &PathBuf, remote_url: &Url, remote_manifest: RemoteManifest, local_filedata: &HashMap<PathBuf, LocalManifestFileEntry>, force_verify: bool) -> anyhow::Result<(Vec<(Url, RemoteManifestFileEntry)>, usize, usize)> {
+fn verify_local_files(
+    output: &Path,
+    remote_url: &Url,
+    remote_manifest: RemoteManifest,
+    local_filedata: &HashMap<PathBuf, LocalManifestFileEntry>,
+    force_verify: bool,
+) -> anyhow::Result<(Vec<(Url, RemoteManifestFileEntry)>, usize, usize)> {
     info!("Checking local files");
 
     let mut files_to_update = Vec::new();
@@ -198,7 +212,10 @@ fn verify_local_files(output: &PathBuf, remote_url: &Url, remote_manifest: Remot
         total_size += remote_entry.source_size;
 
         if !force_verify && !needs_update() {
-            debug!("Skipping file {} as it is already present", output_path.display());
+            debug!(
+                "Skipping file {} as it is already present",
+                output_path.display()
+            );
             already_downloaded_size += remote_entry.source_size;
             continue;
         }
@@ -210,9 +227,13 @@ fn verify_local_files(output: &PathBuf, remote_url: &Url, remote_manifest: Remot
     Ok((files_to_update, total_size, already_downloaded_size))
 }
 
-fn get_remote_files(output: &PathBuf, files_to_update: Vec<(Url, RemoteManifestFileEntry)>, main_updater: MainProgressUpdater, shutdown_rx: tokio::sync::watch::Receiver<bool>, tx: tokio::sync::mpsc::Sender<LocalManifestFileEntry>)
-    -> anyhow::Result<Vec<tokio::task::JoinHandle<()>>> {
-
+fn get_remote_files(
+    output: &Path,
+    files_to_update: Vec<(Url, RemoteManifestFileEntry)>,
+    main_updater: MainProgressUpdater,
+    shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    tx: tokio::sync::mpsc::Sender<LocalManifestFileEntry>,
+) -> anyhow::Result<Vec<tokio::task::JoinHandle<()>>> {
     let mut clone_tasks = Vec::new();
 
     for entry in files_to_update {
@@ -248,10 +269,11 @@ fn get_remote_files(output: &PathBuf, files_to_update: Vec<(Url, RemoteManifestF
     Ok(clone_tasks)
 }
 
-async fn process(args: &Args,
-                 main_updater: MainProgressUpdater,
-                 mut shutdown_rx: tokio::sync::watch::Receiver<bool>) -> anyhow::Result<DownloadResult> {
-
+async fn process(
+    args: &Args,
+    main_updater: MainProgressUpdater,
+    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+) -> anyhow::Result<DownloadResult> {
     let remote_url =
         Url::parse(&args.url).context(format!("Failed to parse the url {}", args.url))?;
 
@@ -264,7 +286,7 @@ async fn process(args: &Args,
     let local_manifest_path = args
         .output
         .join("updater")
-        .join(&remote_url.host_str().unwrap_or("default"))
+        .join(remote_url.host_str().unwrap_or("default"))
         .join("local_manifest.json");
 
     let local_manifest = tokio::select! {
@@ -281,7 +303,9 @@ async fn process(args: &Args,
     if args.force_recheck_updater || updater_needs_update {
         let local_updater_path = args.output.join(&remote_manifest.updater.source_path);
 
-        main_updater.set_max_progress(remote_manifest.updater.source_size).await;
+        main_updater
+            .set_max_progress(remote_manifest.updater.source_size)
+            .await;
 
         let remote = remote_url.join(&remote_manifest.updater.path)?;
 
@@ -323,10 +347,18 @@ async fn process(args: &Args,
         current_local_filedata.insert(PathBuf::from(&entry.path), entry.clone());
     }
 
-    let (files_to_download, total_size, already_downloaded_size) = verify_local_files(&args.output, &remote_url, remote_manifest, &current_local_filedata, args.verify)?;
+    let (files_to_download, total_size, already_downloaded_size) = verify_local_files(
+        &args.output,
+        &remote_url,
+        remote_manifest,
+        &current_local_filedata,
+        args.verify,
+    )?;
 
     main_updater.set_max_progress(total_size).await;
-    main_updater.increment_progress(already_downloaded_size).await;
+    main_updater
+        .increment_progress(already_downloaded_size)
+        .await;
 
     let (tx, mut rx) = tokio::sync::mpsc::channel::<LocalManifestFileEntry>(64);
 
@@ -346,8 +378,14 @@ async fn process(args: &Args,
         (hash_new_local_manifest, new_local_manifest)
     });
 
-    let clone_tasks = get_remote_files(&args.output, files_to_download, main_updater, shutdown_rx, tx)?;
-    
+    let clone_tasks = get_remote_files(
+        &args.output,
+        files_to_download,
+        main_updater,
+        shutdown_rx,
+        tx,
+    )?;
+
     futures::future::join_all(clone_tasks).await;
     let (hash_new_local_manifest, mut new_local_manifest) = work.await?;
 
@@ -373,26 +411,26 @@ enum Message {
     MainProgressUpdate(MainProgressUpdaterEvent),
     Launch,
     Shutdown,
-    Error
+    Error,
 }
 
 #[derive(Clone)]
 struct MainProgressUpdater {
-    sender: app::Sender::<Message>,
+    sender: app::Sender<Message>,
 }
 
 #[async_trait]
 impl Updater for MainProgressUpdater {
     async fn set_max_progress(&self, total: usize) {
-        self
-            .sender
-            .send(Message::MainProgressUpdate(MainProgressUpdaterEvent::SetMaxProgress(total)));
+        self.sender.send(Message::MainProgressUpdate(
+            MainProgressUpdaterEvent::SetMaxProgress(total),
+        ));
     }
 
     async fn increment_progress(&self, amount: usize) {
-        self
-            .sender
-            .send(Message::MainProgressUpdate(MainProgressUpdaterEvent::IncrementProgress(amount)));
+        self.sender.send(Message::MainProgressUpdate(
+            MainProgressUpdaterEvent::IncrementProgress(amount),
+        ));
     }
 }
 
@@ -482,9 +520,7 @@ fn main() -> anyhow::Result<()> {
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
     // Create our updaters
-    let main_updater = MainProgressUpdater {
-        sender: tx.clone(),
-    };
+    let main_updater = MainProgressUpdater { sender: tx.clone() };
 
     // Clone some args before moving args into download task
     let exe = args.exe.clone();
@@ -493,21 +529,21 @@ fn main() -> anyhow::Result<()> {
 
     // When the launch button is clicked we start the application
     launch_button.set_callback(move |_| {
-            info!(
-                "Executing Command: {}/{} {}",
-                exe_dir.display(),
-                exe.display(),
-                exe_args.join(" ")
-            );
+        info!(
+            "Executing Command: {}/{} {}",
+            exe_dir.display(),
+            exe.display(),
+            exe_args.join(" ")
+        );
 
-            Command::new(&exe)
-                .current_dir(&exe_dir)
-                .args(&exe_args)
-                .spawn()
-                .unwrap();
-            
-            app.clone().quit();
-        });
+        Command::new(&exe)
+            .current_dir(&exe_dir)
+            .args(&exe_args)
+            .spawn()
+            .unwrap();
+
+        app.quit();
+    });
 
     let rt = tokio::runtime::Runtime::new().unwrap();
 
@@ -531,7 +567,10 @@ fn main() -> anyhow::Result<()> {
                 }
             }
         } else {
-            error!("Download task failed or cancelled, error {}", result.err().unwrap());
+            error!(
+                "Download task failed or cancelled, error {}",
+                result.err().unwrap()
+            );
             tx.send(Message::Error);
         }
     });
@@ -539,20 +578,18 @@ fn main() -> anyhow::Result<()> {
     while app.wait() {
         if let Some(e) = rx.recv() {
             match e {
-                Message::MainProgressUpdate(e) => {
-                    match e {
-                        MainProgressUpdaterEvent::SetMaxProgress(amount) => {
-                            main_progress_bar.set_minimum(0);
-                            main_progress_bar.set_maximum(amount);
-                            main_progress_bar.set_value(0);
-                            background_frame.redraw();
-                            main_progress_bar.redraw();
-                            launch_button.redraw();
-                        }
-                        MainProgressUpdaterEvent::IncrementProgress(amount) => {
-                            main_progress_bar.set_value(main_progress_bar.value() + amount);
-                            main_progress_bar.redraw();
-                        }
+                Message::MainProgressUpdate(e) => match e {
+                    MainProgressUpdaterEvent::SetMaxProgress(amount) => {
+                        main_progress_bar.set_minimum(0);
+                        main_progress_bar.set_maximum(amount);
+                        main_progress_bar.set_value(0);
+                        background_frame.redraw();
+                        main_progress_bar.redraw();
+                        launch_button.redraw();
+                    }
+                    MainProgressUpdaterEvent::IncrementProgress(amount) => {
+                        main_progress_bar.set_value(main_progress_bar.value() + amount);
+                        main_progress_bar.redraw();
                     }
                 },
                 Message::Launch => {
@@ -560,13 +597,17 @@ fn main() -> anyhow::Result<()> {
                     launch_button.activate();
                     launch_button.change_state(launch_button::LaunchButtonState::Play);
                     launch_button.redraw();
-                },
+                }
                 Message::Shutdown => {
                     info!("Shutting down");
                     break;
-                },
+                }
                 Message::Error => {
-                    dialog::alert((app::screen_size().0 / 2.0) as i32, (app::screen_size().0 / 2.0) as i32,"An error was detected, please restart the launcher");
+                    dialog::alert(
+                        (app::screen_size().0 / 2.0) as i32,
+                        (app::screen_size().0 / 2.0) as i32,
+                        "An error was detected, please restart the launcher",
+                    );
                     break;
                 }
             }
@@ -584,6 +625,6 @@ fn main() -> anyhow::Result<()> {
     if result.is_err() {
         error!("Error while closing down download process");
     }
-    
+
     Ok(())
 }

--- a/src/bin/rose-updater.rs
+++ b/src/bin/rose-updater.rs
@@ -42,6 +42,10 @@ struct Args {
     #[clap(long, default_value = "manifest.json")]
     manifest_name: String,
 
+    /// Skip checking for updater update and only update data files
+    #[clap(long)]
+    skip_updater: bool,
+
     /// Ignore the local manifest in the cache and force all files to be checked
     #[clap(long)]
     force_recheck: bool,
@@ -300,7 +304,7 @@ async fn process(
     let updater_output_path = args.output.join(&remote_manifest.updater.source_path);
     let updater_needs_update = remote_manifest.updater.source_hash != local_manifest.updater.hash;
 
-    if args.force_recheck_updater || updater_needs_update {
+    if !args.skip_updater && (args.force_recheck_updater || updater_needs_update) {
         let local_updater_path = args.output.join(&remote_manifest.updater.source_path);
 
         main_updater

--- a/src/launch_button.rs
+++ b/src/launch_button.rs
@@ -33,7 +33,7 @@ impl LaunchButton {
                     LaunchButtonState::Updating => updating_state,
                     LaunchButtonState::Play => play_state,
                 };
-                let mut png = PngImage::from_data(&image_data).unwrap();
+                let mut png = PngImage::from_data(image_data).unwrap();
                 png.draw(f.x(), f.y(), png.width(), png.height());
             }
         });

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -22,8 +22,10 @@ impl ProgressBar {
         let progress_bar_bytes = include_bytes!("../res/Launcher_Alpha_LoadingBar.png");
         let font_bytes = include_bytes!("../res/JosefinSans-Bold.ttf");
         let black_bytes = include_bytes!("../res/ariblk.ttf");
-        Font::set_font(Font::Helvetica, std::str::from_utf8(font_bytes).unwrap());
-        Font::set_font(Font::Courier, std::str::from_utf8(black_bytes).unwrap());
+        unsafe {
+            Font::set_font(Font::Helvetica, std::str::from_utf8_unchecked(font_bytes));
+            Font::set_font(Font::Courier, std::str::from_utf8_unchecked(black_bytes));
+        }
         let mut bar = Frame::new(x, y, 546, 56 + 30, "");
         let min = Arc::new(AtomicUsize::new(0));
         let max = Arc::new(AtomicUsize::new(0));

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -1,5 +1,5 @@
 use std::ops::{Deref, DerefMut};
-use std::sync::atomic::{AtomicI32, AtomicUsize, AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use fltk::enums::{Align, Color, Font, FrameType};
@@ -14,7 +14,7 @@ pub struct ProgressBar {
     max: Arc<AtomicUsize>,
     value: Arc<AtomicUsize>,
     max_size: Arc<AtomicI32>,
-    is_zero: Arc<AtomicBool>
+    is_zero: Arc<AtomicBool>,
 }
 
 impl ProgressBar {
@@ -22,12 +22,8 @@ impl ProgressBar {
         let progress_bar_bytes = include_bytes!("../res/Launcher_Alpha_LoadingBar.png");
         let font_bytes = include_bytes!("../res/JosefinSans-Bold.ttf");
         let black_bytes = include_bytes!("../res/ariblk.ttf");
-        Font::set_font(Font::Helvetica, unsafe {
-            std::mem::transmute::<&[u8], &str>(font_bytes)
-        });
-        Font::set_font(Font::Courier, unsafe {
-            std::mem::transmute::<&[u8], &str>(black_bytes)
-        });
+        Font::set_font(Font::Helvetica, std::str::from_utf8(font_bytes).unwrap());
+        Font::set_font(Font::Courier, std::str::from_utf8(black_bytes).unwrap());
         let mut bar = Frame::new(x, y, 546, 56 + 30, "");
         let min = Arc::new(AtomicUsize::new(0));
         let max = Arc::new(AtomicUsize::new(0));
@@ -56,11 +52,7 @@ impl ProgressBar {
                     (value * png.width() as usize) / (max - min)
                 };
 
-                let width = if is_zero {
-                    png.width() as usize
-                } else {
-                    width
-                };
+                let width = if is_zero { png.width() as usize } else { width };
 
                 png.draw(b.x(), b.y(), width as i32, png.height());
 
@@ -72,11 +64,7 @@ impl ProgressBar {
                 } else {
                     (value * 100) / (max - min)
                 };
-                let percentage = if is_zero {
-                    100
-                } else {
-                    percentage
-                };
+                let percentage = if is_zero { 100 } else { percentage };
                 let percentage = format!("{}%", percentage);
                 let size = draw::width(&percentage);
                 if size + 20.0 <= width as f64 || is_zero {
@@ -144,7 +132,7 @@ impl ProgressBar {
             max,
             value,
             max_size,
-            is_zero
+            is_zero,
         }
     }
 


### PR DESCRIPTION
This fixes the updater to run on Wine 8.0+. The updater would previously fail to download the manifest due to `reqwest` using `native-tls` by default which was failing under wine when hitting an HTTPS endpoint. Forcing `reqwest` to use `rustls-tls` instead resolve the issue.

Wine versions <8.0 are still broken/unsupported due to a bug in Wine triggered by mio, see https://github.com/tokio-rs/mio/issues/1444 for more details.

Additionally, rustfmt was reapplied to the source code and most clippy warnings were resolved.