### PR TITLE
Add support to clean download text files

### DIFF
--- a/src/bin/rose-updater.rs
+++ b/src/bin/rose-updater.rs
@@ -65,7 +65,7 @@ struct Args {
     verify: bool,
 
     /// Executable to run after updating
-    #[clap(default_value = "trose.exe")]
+    #[clap(long, default_value = "trose.exe")]
     exe: PathBuf,
 
     /// Arguments for the executable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod bitar_ext;
 pub mod launch_button;
-pub mod progress_bar;
 pub mod manifest;
+pub mod progress_bar;
 
 pub use bitar_ext::*;
 pub use manifest::*;

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -13,7 +13,7 @@ pub struct ProgressBar {
     min: Arc<AtomicUsize>,
     max: Arc<AtomicUsize>,
     value: Arc<AtomicUsize>,
-    max_size: Arc<AtomicI32>,
+    _max_size: Arc<AtomicI32>,
     is_zero: Arc<AtomicBool>,
 }
 
@@ -133,7 +133,7 @@ impl ProgressBar {
             min,
             max,
             value,
-            max_size,
+            _max_size: max_size,
             is_zero,
         }
     }


### PR DESCRIPTION
It seems bitar does not handle text files well when downloading an archive and reconciling chunks in an existing file. Everytime we update an XML file the updater corrupts the existing one on disk and users need to delete the file and updater manifest to force a clean download. This commit adds a special handling case for text files where it will always delete the on disk file first forcing bitar to do a full clean download of the remote archive.

Additionally, some clippy warnings were fixed and a bug where the play button would break when running the updater from a script was fixed.

Closes #6 