### PR TITLE
Use ShellExecuteExW instead of CreateProcess

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,10 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Run rose-updater tests (Windows only)
+        if: matrix.os == 'windows-latest'
+        run: cargo test --bin rose-updater
+
       - name: Build in release mode
         run: cargo build --release
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 # Rust
 target/
+
+.idea/
+
+.codex
+.claude

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "rose_update"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "bitar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ walkdir = "2"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.62.0", features = ["Win32_System_Threading", "Win32_UI_Shell"] }
+windows = { version = "0.62.0", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_UI_Shell"] }
 
 [build-dependencies]
 [target.'cfg(windows)'.build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ walkdir = "2"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.62.0", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_UI_Shell"] }
+windows = { version = "0.62.0", features = ["Win32_Foundation", "Win32_System_Registry", "Win32_System_Threading", "Win32_UI_Shell"] }
 
 [build-dependencies]
 [target.'cfg(windows)'.build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ walkdir = "2"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.62.0", features = ["Win32_System_Threading"] }
+windows = { version = "0.62.0", features = ["Win32_System_Threading", "Win32_UI_Shell"] }
 
 [build-dependencies]
 [target.'cfg(windows)'.build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rose_update"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Ralph Minderhoud <ralph@rednim.com>"]
 edition = "2021"
 

--- a/src/bin/rose-updater/main.rs
+++ b/src/bin/rose-updater/main.rs
@@ -26,9 +26,7 @@ use windows::core::PCWSTR;
 #[cfg(windows)]
 use windows::Win32::Foundation::ERROR_ELEVATION_REQUIRED;
 #[cfg(windows)]
-use windows::Win32::UI::Shell::{
-    ShellExecuteExW, SEE_MASK_NOASYNC, SHELLEXECUTEINFOW, SHELLEXECUTE_MASK_FLAGS,
-};
+use windows::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOASYNC, SHELLEXECUTEINFOW};
 
 use rose_update::clone::{
     build_local_chunk_index, clone_remote_file, estimate_local_chunk_count,
@@ -203,34 +201,17 @@ fn spawn_process_std(exe: &Path, args: &[String], working_dir: Option<&Path>) ->
 }
 
 #[cfg(windows)]
-#[derive(Debug)]
-struct ShellExecuteSpec {
-    file: PathBuf,
-    parameters: Option<Vec<u16>>,
-    directory: Option<PathBuf>,
-    mask: SHELLEXECUTE_MASK_FLAGS,
-}
-
-#[cfg(windows)]
-fn should_use_shell_fallback(error: &io::Error) -> bool {
-    error.raw_os_error() == Some(ERROR_ELEVATION_REQUIRED.0 as i32)
-}
-
-#[cfg(windows)]
-fn resolve_shell_file(exe: &Path, working_dir: Option<&Path>) -> io::Result<PathBuf> {
-    let exe = if exe.is_absolute() {
-        exe.to_path_buf()
-    } else if let Some(dir) = working_dir {
-        if let Ok(stripped) = exe.strip_prefix(dir) {
-            dir.join(stripped)
-        } else {
-            dir.join(exe)
-        }
-    } else {
-        exe.to_path_buf()
+fn resolve_shell_paths(
+    exe: &Path,
+    working_dir: Option<&Path>,
+) -> io::Result<(PathBuf, Option<PathBuf>)> {
+    let directory = working_dir.map(std::path::absolute).transpose()?;
+    let file = match directory.as_ref() {
+        Some(dir) if !exe.is_absolute() => dir.join(exe),
+        _ => exe.to_path_buf(),
     };
 
-    std::path::absolute(exe)
+    Ok((std::path::absolute(file)?, directory))
 }
 
 #[cfg(windows)]
@@ -276,31 +257,7 @@ fn encode_windows_command_line(args: &[String]) -> Vec<u16> {
 }
 
 #[cfg(windows)]
-fn build_shell_execute_spec(
-    exe: &Path,
-    args: &[String],
-    working_dir: Option<&Path>,
-) -> io::Result<ShellExecuteSpec> {
-    let file = resolve_shell_file(exe, working_dir)?;
-    let directory = working_dir.map(std::path::absolute).transpose()?;
-    let parameters = (!args.is_empty()).then(|| {
-        let mut encoded = encode_windows_command_line(args);
-        encoded.push(0);
-        encoded
-    });
-
-    Ok(ShellExecuteSpec {
-        file,
-        parameters,
-        directory,
-        // The launcher exits almost immediately after a successful ShellExecuteExW call.
-        // Force the shell work to complete on this thread before returning.
-        mask: SEE_MASK_NOASYNC,
-    })
-}
-
-#[cfg(windows)]
-fn spawn_process_shell(spec: &ShellExecuteSpec) -> anyhow::Result<()> {
+fn spawn_process_shell(exe: &Path, args: &[String], working_dir: Option<&Path>) -> anyhow::Result<()> {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
 
@@ -308,15 +265,23 @@ fn spawn_process_shell(spec: &ShellExecuteSpec) -> anyhow::Result<()> {
         value.encode_wide().chain(std::iter::once(0)).collect()
     }
 
-    let file_wide = to_wide(spec.file.as_os_str());
-    let dir_wide = spec.directory.as_ref().map(|dir| to_wide(dir.as_os_str()));
+    let (file, directory) = resolve_shell_paths(exe, working_dir)?;
+    let parameters = (!args.is_empty()).then(|| {
+        let mut encoded = encode_windows_command_line(args);
+        encoded.push(0);
+        encoded
+    });
+
+    let file_wide = to_wide(file.as_os_str());
+    let dir_wide = directory.as_ref().map(|dir| to_wide(dir.as_os_str()));
 
     let mut info: SHELLEXECUTEINFOW = unsafe { std::mem::zeroed() };
     info.cbSize = std::mem::size_of::<SHELLEXECUTEINFOW>() as u32;
-    info.fMask = spec.mask;
+    // The launcher exits almost immediately after a successful ShellExecuteExW call.
+    // Force the shell work to complete on this thread before returning.
+    info.fMask = SEE_MASK_NOASYNC;
     info.lpFile = PCWSTR(file_wide.as_ptr());
-    info.lpParameters = spec
-        .parameters
+    info.lpParameters = parameters
         .as_ref()
         .map_or(PCWSTR::null(), |params| PCWSTR(params.as_ptr()));
     info.lpDirectory = dir_wide
@@ -333,9 +298,8 @@ fn spawn_process_shell(spec: &ShellExecuteSpec) -> anyhow::Result<()> {
 fn spawn_process(exe: &Path, args: &[String], working_dir: Option<&Path>) -> anyhow::Result<()> {
     match spawn_process_std(exe, args, working_dir) {
         Ok(()) => Ok(()),
-        Err(error) if should_use_shell_fallback(&error) => {
-            let spec = build_shell_execute_spec(exe, args, working_dir)?;
-            spawn_process_shell(&spec)
+        Err(error) if error.raw_os_error() == Some(ERROR_ELEVATION_REQUIRED.0 as i32) => {
+            spawn_process_shell(exe, args, working_dir)
         }
         Err(error) => Err(error.into()),
     }
@@ -450,76 +414,57 @@ mod windows_spawn_tests {
 
     #[test]
     fn resolves_default_windows_launch_paths_to_absolute() {
-        let spec =
-            build_shell_execute_spec(Path::new("trose.exe"), &[], Some(Path::new("."))).unwrap();
+        let (file, directory) =
+            resolve_shell_paths(Path::new("trose.exe"), Some(Path::new("."))).unwrap();
 
         assert_eq!(
-            spec.file,
+            file,
             std::path::absolute(Path::new("./trose.exe")).unwrap()
         );
         assert_eq!(
-            spec.directory,
+            directory,
             Some(std::path::absolute(Path::new(".")).unwrap())
         );
     }
 
     #[test]
     fn resolves_relative_executable_against_custom_directory() {
-        let spec =
-            build_shell_execute_spec(Path::new("trose.exe"), &[], Some(Path::new("game"))).unwrap();
+        let (file, directory) =
+            resolve_shell_paths(Path::new("trose.exe"), Some(Path::new("game"))).unwrap();
 
         assert_eq!(
-            spec.file,
+            file,
             std::path::absolute(Path::new("game/trose.exe")).unwrap()
         );
         assert_eq!(
-            spec.directory,
+            directory,
             Some(std::path::absolute(Path::new("game")).unwrap())
-        );
-    }
-
-    #[test]
-    fn does_not_join_prefixed_relative_paths_twice() {
-        let spec =
-            build_shell_execute_spec(Path::new("game/trose.exe"), &[], Some(Path::new("game")))
-                .unwrap();
-
-        assert_eq!(
-            spec.file,
-            std::path::absolute(Path::new("game/trose.exe")).unwrap()
         );
     }
 
     #[test]
     fn preserves_absolute_executable_paths() {
         let absolute_exe = std::path::absolute(Path::new("trose.exe")).unwrap();
-        let spec = build_shell_execute_spec(&absolute_exe, &[], Some(Path::new("game"))).unwrap();
+        let (file, directory) =
+            resolve_shell_paths(&absolute_exe, Some(Path::new("game"))).unwrap();
 
-        assert_eq!(spec.file, absolute_exe);
+        assert_eq!(file, absolute_exe);
         assert_eq!(
-            spec.directory,
+            directory,
             Some(std::path::absolute(Path::new("game")).unwrap())
         );
     }
 
     #[test]
     fn falls_back_only_for_elevation_required() {
-        assert!(should_use_shell_fallback(&io::Error::from_raw_os_error(
+        assert_eq!(
+            io::Error::from_raw_os_error(ERROR_ELEVATION_REQUIRED.0 as i32).raw_os_error(),
+            Some(ERROR_ELEVATION_REQUIRED.0 as i32)
+        );
+        assert_ne!(
+            io::Error::from_raw_os_error(5).raw_os_error(),
             ERROR_ELEVATION_REQUIRED.0 as i32
-        )));
-        assert!(!should_use_shell_fallback(&io::Error::from_raw_os_error(5)));
-    }
-
-    #[test]
-    fn shell_execute_request_sets_no_async_mask() {
-        let spec = build_shell_execute_spec(
-            Path::new("trose.exe"),
-            &["--init".to_string()],
-            Some(Path::new(".")),
-        )
-        .unwrap();
-
-        assert_eq!(spec.mask, SEE_MASK_NOASYNC);
+        );
     }
 }
 
@@ -969,7 +914,7 @@ async fn main() -> anyhow::Result<()> {
             exe_args.join(" ")
         );
 
-        let exe = exe_dir.join(&exe);
+        let display_exe = exe_dir.join(&exe);
 
         match spawn_process(&exe, &exe_args, Some(&exe_dir)) {
             Ok(_) => {
@@ -983,7 +928,7 @@ async fn main() -> anyhow::Result<()> {
                     .set_description(format!(
                         "{}\n\nMake sure '{}' exists in the game folder.\n\nDetails: {}",
                         ErrorCode::LaunchGame,
-                        exe.display(),
+                        display_exe.display(),
                         e
                     ))
                     .show();

--- a/src/bin/rose-updater/main.rs
+++ b/src/bin/rose-updater/main.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::env;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process;
 
@@ -20,6 +21,14 @@ use tokio::fs;
 use tracing::{error, info, Level};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Layer;
+#[cfg(windows)]
+use windows::core::PCWSTR;
+#[cfg(windows)]
+use windows::Win32::Foundation::ERROR_ELEVATION_REQUIRED;
+#[cfg(windows)]
+use windows::Win32::UI::Shell::{
+    ShellExecuteExW, SEE_MASK_NOASYNC, SHELLEXECUTEINFOW, SHELLEXECUTE_MASK_FLAGS,
+};
 
 use rose_update::clone::{
     build_local_chunk_index, clone_remote_file, estimate_local_chunk_count,
@@ -180,57 +189,7 @@ async fn update_updater(
     Ok(())
 }
 
-/// Spawn a detached process. On Windows, uses `ShellExecuteExW` instead of `CreateProcess`
-/// so that executables with a UAC elevation manifest are handled correctly (avoids
-/// error 740 / ERROR_ELEVATION_REQUIRED that `std::process::Command::spawn` would return).
-#[cfg(windows)]
-fn spawn_process(exe: &Path, args: &[String], working_dir: Option<&Path>) -> anyhow::Result<()> {
-    use std::ffi::OsStr;
-    use std::os::windows::ffi::OsStrExt;
-    use windows::core::PCWSTR;
-    use windows::Win32::UI::Shell::{ShellExecuteExW, SHELLEXECUTEINFOW};
-
-    fn to_wide(s: &OsStr) -> Vec<u16> {
-        s.encode_wide().chain(std::iter::once(0)).collect()
-    }
-
-    fn args_to_wide(args: &[String]) -> Vec<u16> {
-        let joined = args
-            .iter()
-            .map(|a| {
-                if a.contains(' ') {
-                    format!("\"{}\"", a.replace('"', "\\\""))
-                } else {
-                    a.clone()
-                }
-            })
-            .collect::<Vec<_>>()
-            .join(" ");
-        to_wide(OsStr::new(&joined))
-    }
-
-    let file_wide = to_wide(exe.as_os_str());
-    let params_wide = args_to_wide(args);
-    let dir_wide = working_dir.map(|d| to_wide(d.as_os_str()));
-
-    let mut info: SHELLEXECUTEINFOW = unsafe { std::mem::zeroed() };
-    info.cbSize = std::mem::size_of::<SHELLEXECUTEINFOW>() as u32;
-    info.lpFile = PCWSTR(file_wide.as_ptr());
-    info.lpParameters = if args.is_empty() {
-        PCWSTR::null()
-    } else {
-        PCWSTR(params_wide.as_ptr())
-    };
-    info.lpDirectory = dir_wide
-        .as_ref()
-        .map_or(PCWSTR::null(), |d| PCWSTR(d.as_ptr()));
-    info.nShow = 1; // SW_SHOWNORMAL
-
-    unsafe { ShellExecuteExW(&mut info) }.map_err(|e| anyhow::anyhow!("{}", e))
-}
-
-#[cfg(not(windows))]
-fn spawn_process(exe: &Path, args: &[String], working_dir: Option<&Path>) -> anyhow::Result<()> {
+fn spawn_process_std(exe: &Path, args: &[String], working_dir: Option<&Path>) -> io::Result<()> {
     let mut cmd = process::Command::new(exe);
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
@@ -241,6 +200,327 @@ fn spawn_process(exe: &Path, args: &[String], working_dir: Option<&Path>) -> any
         .stderr(process::Stdio::null())
         .spawn()?;
     Ok(())
+}
+
+#[cfg(windows)]
+#[derive(Debug)]
+struct ShellExecuteSpec {
+    file: PathBuf,
+    parameters: Option<Vec<u16>>,
+    directory: Option<PathBuf>,
+    mask: SHELLEXECUTE_MASK_FLAGS,
+}
+
+#[cfg(windows)]
+fn should_use_shell_fallback(error: &io::Error) -> bool {
+    error.raw_os_error() == Some(ERROR_ELEVATION_REQUIRED.0 as i32)
+}
+
+#[cfg(windows)]
+fn resolve_shell_file(exe: &Path, working_dir: Option<&Path>) -> io::Result<PathBuf> {
+    let exe = if exe.is_absolute() {
+        exe.to_path_buf()
+    } else if let Some(dir) = working_dir {
+        if let Ok(stripped) = exe.strip_prefix(dir) {
+            dir.join(stripped)
+        } else {
+            dir.join(exe)
+        }
+    } else {
+        exe.to_path_buf()
+    };
+
+    std::path::absolute(exe)
+}
+
+#[cfg(windows)]
+fn append_windows_arg(cmd: &mut Vec<u16>, arg: &str) {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+
+    let bytes = arg.as_bytes();
+    let quote = bytes.iter().any(|byte| matches!(*byte, b' ' | b'\t')) || bytes.is_empty();
+    if quote {
+        cmd.push('"' as u16);
+    }
+
+    let mut backslashes = 0usize;
+    for code_unit in OsStr::new(arg).encode_wide() {
+        if code_unit == '\\' as u16 {
+            backslashes += 1;
+        } else {
+            if code_unit == '"' as u16 {
+                cmd.extend((0..=backslashes).map(|_| '\\' as u16));
+            }
+            backslashes = 0;
+        }
+        cmd.push(code_unit);
+    }
+
+    if quote {
+        cmd.extend((0..backslashes).map(|_| '\\' as u16));
+        cmd.push('"' as u16);
+    }
+}
+
+#[cfg(windows)]
+fn encode_windows_command_line(args: &[String]) -> Vec<u16> {
+    let mut command_line = Vec::new();
+    for (index, arg) in args.iter().enumerate() {
+        if index > 0 {
+            command_line.push(' ' as u16);
+        }
+        append_windows_arg(&mut command_line, arg);
+    }
+    command_line
+}
+
+#[cfg(windows)]
+fn build_shell_execute_spec(
+    exe: &Path,
+    args: &[String],
+    working_dir: Option<&Path>,
+) -> io::Result<ShellExecuteSpec> {
+    let file = resolve_shell_file(exe, working_dir)?;
+    let directory = working_dir.map(std::path::absolute).transpose()?;
+    let parameters = (!args.is_empty()).then(|| {
+        let mut encoded = encode_windows_command_line(args);
+        encoded.push(0);
+        encoded
+    });
+
+    Ok(ShellExecuteSpec {
+        file,
+        parameters,
+        directory,
+        // The launcher exits almost immediately after a successful ShellExecuteExW call.
+        // Force the shell work to complete on this thread before returning.
+        mask: SEE_MASK_NOASYNC,
+    })
+}
+
+#[cfg(windows)]
+fn spawn_process_shell(spec: &ShellExecuteSpec) -> anyhow::Result<()> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+
+    fn to_wide(value: &OsStr) -> Vec<u16> {
+        value.encode_wide().chain(std::iter::once(0)).collect()
+    }
+
+    let file_wide = to_wide(spec.file.as_os_str());
+    let dir_wide = spec.directory.as_ref().map(|dir| to_wide(dir.as_os_str()));
+
+    let mut info: SHELLEXECUTEINFOW = unsafe { std::mem::zeroed() };
+    info.cbSize = std::mem::size_of::<SHELLEXECUTEINFOW>() as u32;
+    info.fMask = spec.mask;
+    info.lpFile = PCWSTR(file_wide.as_ptr());
+    info.lpParameters = spec
+        .parameters
+        .as_ref()
+        .map_or(PCWSTR::null(), |params| PCWSTR(params.as_ptr()));
+    info.lpDirectory = dir_wide
+        .as_ref()
+        .map_or(PCWSTR::null(), |dir| PCWSTR(dir.as_ptr()));
+    info.nShow = 1; // SW_SHOWNORMAL
+
+    unsafe { ShellExecuteExW(&mut info) }.map_err(|error| anyhow::anyhow!("{}", error))
+}
+
+/// Spawn a detached process. On Windows, try the standard library's CreateProcess path first
+/// and only fall back to ShellExecuteExW for executables that require elevation.
+#[cfg(windows)]
+fn spawn_process(exe: &Path, args: &[String], working_dir: Option<&Path>) -> anyhow::Result<()> {
+    match spawn_process_std(exe, args, working_dir) {
+        Ok(()) => Ok(()),
+        Err(error) if should_use_shell_fallback(&error) => {
+            let spec = build_shell_execute_spec(exe, args, working_dir)?;
+            spawn_process_shell(&spec)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(not(windows))]
+fn spawn_process(exe: &Path, args: &[String], working_dir: Option<&Path>) -> anyhow::Result<()> {
+    spawn_process_std(exe, args, working_dir)?;
+    Ok(())
+}
+
+#[cfg(all(test, windows))]
+mod windows_spawn_tests {
+    use super::*;
+    use std::ffi::c_void;
+
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn LocalFree(hmem: *mut c_void) -> *mut c_void;
+    }
+
+    #[link(name = "shell32")]
+    unsafe extern "system" {
+        fn CommandLineToArgvW(command_line: *const u16, argc: *mut i32) -> *mut *mut u16;
+    }
+
+    fn parse_command_line(command_line: &[u16]) -> Vec<String> {
+        let mut argc = 0;
+        let argv = unsafe { CommandLineToArgvW(command_line.as_ptr(), &mut argc) };
+        assert!(!argv.is_null(), "CommandLineToArgvW failed");
+
+        let args = unsafe {
+            (0..argc as usize)
+                .map(|index| {
+                    let arg = *argv.add(index);
+                    let mut len = 0usize;
+                    while *arg.add(len) != 0 {
+                        len += 1;
+                    }
+                    String::from_utf16(std::slice::from_raw_parts(arg, len)).unwrap()
+                })
+                .collect()
+        };
+
+        unsafe {
+            let _ = LocalFree(argv.cast());
+        }
+
+        args
+    }
+
+    fn round_trip_shell_args(args: &[String]) -> Vec<String> {
+        let mut command_line: Vec<u16> = "launcher.exe".encode_utf16().collect();
+        let encoded_args = encode_windows_command_line(args);
+        if !encoded_args.is_empty() {
+            command_line.push(' ' as u16);
+            command_line.extend_from_slice(&encoded_args);
+        }
+        command_line.push(0);
+        parse_command_line(&command_line)
+            .into_iter()
+            .skip(1)
+            .collect()
+    }
+
+    #[test]
+    fn preserves_single_trailing_backslash() {
+        let args = vec![r"C:\Program Files\Rose\".to_string()];
+        assert_eq!(round_trip_shell_args(&args), args);
+    }
+
+    #[test]
+    fn preserves_multiple_trailing_backslashes() {
+        let args = vec![r"C:\Program Files\Rose\\".to_string()];
+        assert_eq!(round_trip_shell_args(&args), args);
+    }
+
+    #[test]
+    fn preserves_embedded_quotes() {
+        let args = vec![r#"has\"quote"#.to_string()];
+        assert_eq!(round_trip_shell_args(&args), args);
+    }
+
+    #[test]
+    fn preserves_backslashes_before_quote() {
+        let args = vec![r#"a\\\"b c"#.to_string()];
+        assert_eq!(round_trip_shell_args(&args), args);
+    }
+
+    #[test]
+    fn preserves_empty_arguments() {
+        let args = vec![String::new()];
+        assert_eq!(round_trip_shell_args(&args), args);
+    }
+
+    #[test]
+    fn preserves_tab_arguments() {
+        let args = vec!["a\tb".to_string()];
+        assert_eq!(round_trip_shell_args(&args), args);
+    }
+
+    #[test]
+    fn preserves_multi_argument_command_lines() {
+        let args = vec![
+            "--init".to_string(),
+            "--server".to_string(),
+            "connect.roseonlinegame.com".to_string(),
+            r"C:\Program Files\Rose\".to_string(),
+        ];
+        assert_eq!(round_trip_shell_args(&args), args);
+    }
+
+    #[test]
+    fn resolves_default_windows_launch_paths_to_absolute() {
+        let spec =
+            build_shell_execute_spec(Path::new("trose.exe"), &[], Some(Path::new("."))).unwrap();
+
+        assert_eq!(
+            spec.file,
+            std::path::absolute(Path::new("./trose.exe")).unwrap()
+        );
+        assert_eq!(
+            spec.directory,
+            Some(std::path::absolute(Path::new(".")).unwrap())
+        );
+    }
+
+    #[test]
+    fn resolves_relative_executable_against_custom_directory() {
+        let spec =
+            build_shell_execute_spec(Path::new("trose.exe"), &[], Some(Path::new("game"))).unwrap();
+
+        assert_eq!(
+            spec.file,
+            std::path::absolute(Path::new("game/trose.exe")).unwrap()
+        );
+        assert_eq!(
+            spec.directory,
+            Some(std::path::absolute(Path::new("game")).unwrap())
+        );
+    }
+
+    #[test]
+    fn does_not_join_prefixed_relative_paths_twice() {
+        let spec =
+            build_shell_execute_spec(Path::new("game/trose.exe"), &[], Some(Path::new("game")))
+                .unwrap();
+
+        assert_eq!(
+            spec.file,
+            std::path::absolute(Path::new("game/trose.exe")).unwrap()
+        );
+    }
+
+    #[test]
+    fn preserves_absolute_executable_paths() {
+        let absolute_exe = std::path::absolute(Path::new("trose.exe")).unwrap();
+        let spec = build_shell_execute_spec(&absolute_exe, &[], Some(Path::new("game"))).unwrap();
+
+        assert_eq!(spec.file, absolute_exe);
+        assert_eq!(
+            spec.directory,
+            Some(std::path::absolute(Path::new("game")).unwrap())
+        );
+    }
+
+    #[test]
+    fn falls_back_only_for_elevation_required() {
+        assert!(should_use_shell_fallback(&io::Error::from_raw_os_error(
+            ERROR_ELEVATION_REQUIRED.0 as i32
+        )));
+        assert!(!should_use_shell_fallback(&io::Error::from_raw_os_error(5)));
+    }
+
+    #[test]
+    fn shell_execute_request_sets_no_async_mask() {
+        let spec = build_shell_execute_spec(
+            Path::new("trose.exe"),
+            &["--init".to_string()],
+            Some(Path::new(".")),
+        )
+        .unwrap();
+
+        assert_eq!(spec.mask, SEE_MASK_NOASYNC);
+    }
 }
 
 #[derive(Debug)]

--- a/src/bin/rose-updater/main.rs
+++ b/src/bin/rose-updater/main.rs
@@ -180,6 +180,69 @@ async fn update_updater(
     Ok(())
 }
 
+/// Spawn a detached process. On Windows, uses `ShellExecuteExW` instead of `CreateProcess`
+/// so that executables with a UAC elevation manifest are handled correctly (avoids
+/// error 740 / ERROR_ELEVATION_REQUIRED that `std::process::Command::spawn` would return).
+#[cfg(windows)]
+fn spawn_process(exe: &Path, args: &[String], working_dir: Option<&Path>) -> anyhow::Result<()> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use windows::core::PCWSTR;
+    use windows::Win32::UI::Shell::{ShellExecuteExW, SHELLEXECUTEINFOW};
+
+    fn to_wide(s: &OsStr) -> Vec<u16> {
+        s.encode_wide().chain(std::iter::once(0)).collect()
+    }
+
+    fn args_to_wide(args: &[String]) -> Vec<u16> {
+        let joined = args
+            .iter()
+            .map(|a| {
+                if a.contains(' ') {
+                    format!("\"{}\"", a.replace('"', "\\\""))
+                } else {
+                    a.clone()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        to_wide(OsStr::new(&joined))
+    }
+
+    let file_wide = to_wide(exe.as_os_str());
+    let params_wide = args_to_wide(args);
+    let dir_wide = working_dir.map(|d| to_wide(d.as_os_str()));
+
+    let mut info: SHELLEXECUTEINFOW = unsafe { std::mem::zeroed() };
+    info.cbSize = std::mem::size_of::<SHELLEXECUTEINFOW>() as u32;
+    info.lpFile = PCWSTR(file_wide.as_ptr());
+    info.lpParameters = if args.is_empty() {
+        PCWSTR::null()
+    } else {
+        PCWSTR(params_wide.as_ptr())
+    };
+    info.lpDirectory = dir_wide
+        .as_ref()
+        .map_or(PCWSTR::null(), |d| PCWSTR(d.as_ptr()));
+    info.nShow = 1; // SW_SHOWNORMAL
+
+    unsafe { ShellExecuteExW(&mut info) }.map_err(|e| anyhow::anyhow!("{}", e))
+}
+
+#[cfg(not(windows))]
+fn spawn_process(exe: &Path, args: &[String], working_dir: Option<&Path>) -> anyhow::Result<()> {
+    let mut cmd = process::Command::new(exe);
+    if let Some(dir) = working_dir {
+        cmd.current_dir(dir);
+    }
+    cmd.args(args)
+        .stdin(process::Stdio::null())
+        .stdout(process::Stdio::null())
+        .stderr(process::Stdio::null())
+        .spawn()?;
+    Ok(())
+}
+
 #[derive(Debug)]
 struct FileToDownload {
     /// Path to file in local directory
@@ -461,18 +524,12 @@ async fn update_process(
         info!("Restarting updater");
         let current_exe =
             env::current_exe().context(ErrorCode::FindLauncherLocation.to_string())?;
-        process::Command::new(current_exe)
-            .args(
-                env::args()
-                    .skip(1)
-                    // Prevent infinite loop of update rechecks by removing the forced updater check
-                    .filter(|arg| !arg.contains("force-recheck-updater")),
-            )
-            // Don't share handles so child process can exit cleanly
-            .stdin(process::Stdio::null())
-            .stdout(process::Stdio::null())
-            .stderr(process::Stdio::null())
-            .spawn()
+        let restart_args: Vec<String> = env::args()
+            .skip(1)
+            // Prevent infinite loop of update rechecks by removing the forced updater check
+            .filter(|arg| !arg.contains("force-recheck-updater"))
+            .collect();
+        spawn_process(&current_exe, &restart_args, None)
             .context(ErrorCode::RestartLauncher.to_string())?;
 
         return Ok(UpdateProcessResult::UpdaterUpdated);
@@ -634,15 +691,7 @@ async fn main() -> anyhow::Result<()> {
 
         let exe = exe_dir.join(&exe);
 
-        match process::Command::new(&exe)
-            .current_dir(&exe_dir)
-            .args(&exe_args)
-            // Don't share handles so child process can exit cleanly
-            .stdin(process::Stdio::null())
-            .stdout(process::Stdio::null())
-            .stderr(process::Stdio::null())
-            .spawn()
-        {
+        match spawn_process(&exe, &exe_args, Some(&exe_dir)) {
             Ok(_) => {
                 app.quit();
             }

--- a/src/bin/rose-updater/main.rs
+++ b/src/bin/rose-updater/main.rs
@@ -463,7 +463,7 @@ mod windows_spawn_tests {
         );
         assert_ne!(
             io::Error::from_raw_os_error(5).raw_os_error(),
-            ERROR_ELEVATION_REQUIRED.0 as i32
+            Some(ERROR_ELEVATION_REQUIRED.0 as i32)
         );
     }
 }


### PR DESCRIPTION
Currently `std::process::Command::spawn` is used to spawn the process (self-restart or client start), which ultimately goes through `CreateProcess`. That can fail with `ERROR_ELEVATION_REQUIRED` (error 740) when the target executable has a UAC elevation manifest.

This changes to `ShellExecuteExW` so the elevation permission window pops up for approval instead of failing.